### PR TITLE
Fix handle_sse crashing when client disconnects

### DIFF
--- a/src/homelab_mcp/server.py
+++ b/src/homelab_mcp/server.py
@@ -130,6 +130,7 @@ def main_http():
     import uvicorn
     from mcp.server.sse import SseServerTransport
     from starlette.applications import Starlette
+    from starlette.responses import Response
     from starlette.routing import Route, Mount
 
     # Get configuration from environment
@@ -146,6 +147,7 @@ def main_http():
             await server.run(
                 streams[0], streams[1], server.create_initialization_options()
             )
+        return Response()
 
     # Create Starlette app
     # Mount the handle_post_message as an ASGI app at /messages (Mount adds trailing slash)


### PR DESCRIPTION
The handle_sse function must return a Starlette Response after the SSE connection closes. Without it, Starlette tries to call None as a response, causing 'TypeError: NoneType object is not callable'.

This is documented in the MCP SDK's SseServerTransport:
  'The handle_sse function must return a Response to avoid a NoneType error'